### PR TITLE
fix wrangler.json

### DIFF
--- a/wrangler.json
+++ b/wrangler.json
@@ -3,13 +3,10 @@
   "name": "halqme",
   "pages_build_output_dir": "dist",
   "compatibility_date": "2026-01-20",
-  "env": {
-  },
   "vars": {
     "BUN_VERSION": "latest"
   },
-  "build": {
-    "watch_dir": "./src",
-    "command": "bun run build"
+  "placement":{
+    "mode": "smart"
   }
 }


### PR DESCRIPTION
This pull request updates the `wrangler.json` configuration file, primarily simplifying the build settings and introducing a new placement configuration.

Configuration changes:

* Removed the empty `env` object and the `build` object (including the `watch_dir` and `command` settings) to streamline the configuration.
* Added a new `placement` property with `"mode": "smart"` to the configuration, likely to optimize deployment or resource allocation.