### PR TITLE
add nodejs for build astro

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,14 +1,12 @@
-name: Build and Deploy
-
+name: CI
 on:
-  push:
+  pull_request:
     branches: [main]
-
-permissions:
-  contents: read
+  push:
 
 jobs:
-  build-and-deploy:
+  ci:
+    name: CI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -23,15 +21,6 @@ jobs:
           purge-created: 0
           purge-last-accessed: P1DT12H
           purge-primary-key: never
-
-      - name: Enter Nix devShell, build and deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: |
-          nix develop --command bash -lc '
-            set -euo pipefail
-            bun install --frozen-lockfile
-            bun run build
-            bunx wrangler pages deploy ./dist --project-name=${{ secrets.CLOUDFLARE_PROJECT_NAME }}
-          '
+      - run: nix develop -c bun run format
+      - run: nix develop -c bun run lint
+      - run: nix develop -c bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
           purge-created: 0
           purge-last-accessed: P1DT12H
           purge-primary-key: never
+      - run: nix develop -c bun install --frozen-lockfile
       - run: nix develop -c bun run format
       - run: nix develop -c bun run lint
       - run: nix develop -c bun run build

--- a/flake.nix
+++ b/flake.nix
@@ -12,6 +12,7 @@
     deps = pkgs:
       with pkgs; [
         bun
+        nodejs-slim_24
         typst
       ];
     fonts = pkgs:


### PR DESCRIPTION
This pull request updates the CI and deployment workflows to use improved Nix setup and caching actions, and adds `nodejs-slim_24` as a dependency in the Nix flake. These changes streamline the development environment setup and enhance build performance by leveraging better caching strategies.

**Workflow improvements:**

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R27): Adds a new CI workflow that uses `nixbuild/nix-quick-install-action` and `nix-community/cache-nix-action` for more efficient Nix installation and caching, and runs formatting, linting, and build steps using `bun` within the Nix shell.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L14-R25): Replaces the previous Nix setup and caching actions with `nixbuild/nix-quick-install-action` and `nix-community/cache-nix-action` to unify and optimize the deployment workflow.

**Dependency updates:**

* [`flake.nix`](diffhunk://#diff-206b9ce276ab5971a2489d75eb1b12999d4bf3843b7988cbe8d687cfde61dea0R15): Adds `nodejs-slim_24` to the development dependencies to ensure the correct Node.js version is available in the development environment.