### PR TITLE
refactor: update deployment config and package dependencies

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,5 +33,5 @@ jobs:
             set -euo pipefail
             bun install --frozen-lockfile
             bun run build
-            bunx wrangler pages deploy ./dist --project-name=${{ secrets.CLOUDFLARE_PROJECT_NAME }}
+            bunx wrangler deploy
           '

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
     "build": "astro build && bun run build:cv",
     "build:cv": "bun run scripts/generate-cv-meta.ts && typst compile public/cv.typ dist/cv.pdf",
     "preview": "astro preview",
+    "deploy": "wrangler deploy",
     "astro": "astro",
     "format": "prettier --write . && oxfmt .",
     "lint": "oxlint ."
@@ -34,5 +35,5 @@
     "unocss": "66.6.8",
     "wrangler": "4.90.0"
   },
-  "packageManager": "bun@1.3.11"
+  "packageManager": "bun@1.3.13"
 }

--- a/public/cv.typ
+++ b/public/cv.typ
@@ -44,8 +44,8 @@
 #let website = "https://0w0.foo"
 
 // ファイルメタデータ（ビルド時に自動更新）
-#let file-hash = "8f700b"
-#let last-updated = "2026-03-09"
+#let file-hash = "2c752b"
+#let last-updated = "2026-05-10"
 
 #show: page.with(footer: {
   align(right)[

--- a/wrangler.json
+++ b/wrangler.json
@@ -1,10 +1,23 @@
 {
-  "$schema": "./node_modules/wrangler/config-schema.json",
+  "$schema": "node_modules/wrangler/config-schema.json",
   "name": "halqme",
-  "pages_build_output_dir": "dist",
-  "compatibility_date": "2026-01-20",
-  "vars": {},
-  "placement": {
-    "mode": "smart"
-  }
+  "compatibility_date": "2026-05-10",
+  "observability": {
+    "enabled": true
+  },
+  "assets": {
+    "directory": "dist",
+    "not_found_handling": "404-page"
+  },
+  "compatibility_flags": ["nodejs_compat"],
+  "routes": [
+    {
+      "pattern": "0w0.foo",
+      "custom_domain": true
+    },
+    {
+      "pattern": "www.0w0.foo",
+      "custom_domain": true
+    }
+  ]
 }


### PR DESCRIPTION
This pull request updates the deployment process and configuration for the project, focusing on simplifying deployment commands, updating dependencies, and improving the `wrangler` configuration for Cloudflare. The most important changes are grouped below:

**Deployment Process Improvements:**

* The deploy command in `.github/workflows/deploy.yml` was simplified to use `bunx wrangler deploy`, aligning the workflow with the new recommended approach.
* Added a new `deploy` script to `package.json` for easier local deployment using `wrangler deploy`.

**Cloudflare Wrangler Configuration:**

* Major updates to `wrangler.json`:
  - Updated the schema path and compatibility date.
  - Enabled observability.
  - Added an `assets` section to serve files from the `dist` directory and handle 404s.
  - Enabled the `nodejs_compat` flag for better Node.js compatibility.
  - Defined custom domain routes for `0w0.foo` and `www.0w0.foo`.

**Dependency Updates:**

* Updated the `bun` version in `package.json` from `1.3.11` to `1.3.13` for improved stability and features.

**Document Metadata Update:**

* Updated the hash and last-updated date in `public/cv.typ` to reflect the latest build.